### PR TITLE
Improve layout responsiveness

### DIFF
--- a/src/components/IntroOverlay.astro
+++ b/src/components/IntroOverlay.astro
@@ -1,5 +1,5 @@
-<div id="intro-overlay" class="fixed inset-0 bg-black flex flex-col items-center justify-center text-gray-300 text-center font-jetbrains transition-opacity duration-1000">
-  <h1 class="text-4xl mb-4">Project Arkham</h1>
+<div id="intro-overlay" class="fixed inset-0 bg-black flex flex-col items-center justify-center text-gray-300 text-center font-jetbrains transition-opacity duration-1000 p-4">
+  <h1 class="text-2xl sm:text-4xl mb-4">Project Arkham</h1>
   <p id="intro-quote" class="italic"></p>
 </div>
 <script>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,4 +1,6 @@
-<nav class="p-4 flex space-x-6 border-b border-gray-800">
+<nav
+  class="flex flex-wrap justify-center gap-x-4 gap-y-2 p-4 border-b border-gray-800 text-sm sm:text-base"
+>
   <a href="/" class="hover:text-gray-400">Home</a>
   <a href="/daily-log" class="hover:text-gray-400">Daily Log</a>
   <a href="/fitness" class="hover:text-gray-400">Fitness</a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,7 +10,7 @@ import '../styles/global.css';
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   </head>
-  <body class="bg-black text-gray-100 font-jetbrains min-h-screen">
+  <body class="bg-black text-gray-100 font-jetbrains min-h-screen overflow-x-hidden">
     <slot />
   </body>
 </html>

--- a/src/pages/daily-log.astro
+++ b/src/pages/daily-log.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/pages/fitness.astro
+++ b/src/pages/fitness.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,25 +7,25 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout>
   <IntroOverlay />
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section class="border-b border-gray-800 pb-4">
-      <h1 class="text-2xl mb-2">This Week’s Focus</h1>
-      <p class="text-lg text-gray-300">Minimize distractions. Maximize presence. No wasted motion.</p>
+      <h1 class="text-lg sm:text-xl mb-2">This Week’s Focus</h1>
+      <p class="text-sm sm:text-base text-gray-300">Minimize distractions. Maximize presence. No wasted motion.</p>
     </section>
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your focus, reflection, or insight..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
-    <section class="text-center italic text-gray-400 pt-8">
+    <section class="text-center italic text-gray-400 pt-8 text-sm sm:text-base">
       “In the dark, I’ll find the power to rise.”
     </section>
   </main>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/pages/reviews.astro
+++ b/src/pages/reviews.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,4 +6,7 @@
   html {
     font-family: 'JetBrains Mono', monospace;
   }
+  body {
+    @apply overflow-x-hidden;
+  }
 }


### PR DESCRIPTION
## Summary
- keep intro text compact on small screens
- make navbar horizontal with wrapping
- unify main page containers and mobile typography
- resize textarea and button for mobile

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68428acd007c832285c37c387743b4a9