### PR TITLE
Add vault-style password protection

### DIFF
--- a/src/components/IntroOverlay.astro
+++ b/src/components/IntroOverlay.astro
@@ -1,5 +1,5 @@
-<div id="intro-overlay" class="fixed inset-0 bg-black flex flex-col items-center justify-center text-gray-300 text-center font-jetbrains transition-opacity duration-1000">
-  <h1 class="text-4xl mb-4">Project Arkham</h1>
+<div id="intro-overlay" class="fixed inset-0 bg-black flex flex-col items-center justify-center text-gray-300 text-center font-jetbrains transition-opacity duration-1000 p-4">
+  <h1 class="text-2xl sm:text-4xl mb-4">Project Arkham</h1>
   <p id="intro-quote" class="italic"></p>
 </div>
 <script>
@@ -16,6 +16,8 @@
     overlay.classList.add('opacity-0', 'pointer-events-none');
     setTimeout(() => overlay.remove(), 1000);
   };
-  overlay.addEventListener('click', hide);
-  setTimeout(hide, 3000);
+  document.addEventListener('arkham-auth', hide);
+  if (sessionStorage.getItem('arkhamAuth') === 'true') {
+    hide();
+  }
 </script>

--- a/src/components/MissionPanel.astro
+++ b/src/components/MissionPanel.astro
@@ -1,0 +1,21 @@
+---
+---
+<aside class="hidden lg:block w-56 p-4 border-l border-gray-800 text-xs text-gray-300 font-jetbrains space-y-4">
+  <div>
+    <h2 class="mb-1 text-gray-200">Mission Brief</h2>
+    <p>Every layout should feel like a tool — not a website.</p>
+  </div>
+  <div>
+    <h2 class="mb-1 text-gray-200">Today's Quote</h2>
+    <p id="mission-quote" class="text-gray-400"></p>
+  </div>
+</aside>
+<script>
+  const quotes = [
+    'The training is nothing. The will is everything. – Ra\u2019s al Ghul',
+    'I have to become more. – Bruce Wayne',
+    'In the shadows of my own potential, the Arkham Project begins.',
+    'Endure, master yourself, and rise.'
+  ];
+  document.getElementById('mission-quote').textContent = quotes[Math.floor(Math.random() * quotes.length)];
+</script>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,4 +1,6 @@
-<nav class="p-4 flex space-x-6 border-b border-gray-800">
+<nav
+  class="flex flex-wrap justify-center gap-x-4 gap-y-2 p-4 border-b border-gray-800 text-sm sm:text-base"
+>
   <a href="/" class="hover:text-gray-400">Home</a>
   <a href="/daily-log" class="hover:text-gray-400">Daily Log</a>
   <a href="/fitness" class="hover:text-gray-400">Fitness</a>

--- a/src/components/PasswordGate.astro
+++ b/src/components/PasswordGate.astro
@@ -1,0 +1,41 @@
+---
+---
+<div id="password-gate" class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black text-green-500 font-jetbrains p-4">
+  <div class="text-center">
+    <div class="mb-4">ENTER ACCESS CODE</div>
+    <input id="gate-input" type="password" autocomplete="off" class="bg-black text-green-500 text-center focus:outline-none border-b border-green-500 px-2 py-1 w-48" />
+    <div id="gate-error" class="mt-4 text-red-500 hidden">ACCESS DENIED</div>
+  </div>
+</div>
+<script>
+  const gate = document.getElementById('password-gate');
+  const input = document.getElementById('gate-input');
+  const error = document.getElementById('gate-error');
+  const toHex = buffer => Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+  const hash = '6c25c8f454fea8dd5cd0b201b4f739993aebfc454de7b410ee9457c553699a85';
+  const closeGate = () => {
+    gate.classList.add('opacity-0');
+    setTimeout(() => gate.remove(), 500);
+  };
+  const authenticate = async () => {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input.value));
+    if (toHex(digest) === hash) {
+      sessionStorage.setItem('arkhamAuth', 'true');
+      document.dispatchEvent(new Event('arkham-auth'));
+      closeGate();
+    } else {
+      error.classList.remove('hidden');
+      gate.classList.add('animate-shake');
+      setTimeout(() => gate.classList.remove('animate-shake'), 300);
+    }
+  };
+  gate.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      authenticate();
+    }
+  });
+  if (sessionStorage.getItem('arkhamAuth') === 'true') {
+    document.dispatchEvent(new Event('arkham-auth'));
+    closeGate();
+  }
+</script>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,0 +1,26 @@
+---
+---
+<aside class="hidden lg:flex flex-col justify-between w-40 p-4 border-r border-gray-800 text-gray-400 text-xs font-jetbrains">
+  <div>
+    <div id="sidebar-time" class="text-gray-100"></div>
+    <div id="sidebar-date"></div>
+    <nav class="mt-6 flex flex-col space-y-2">
+      <a href="/" class="hover:text-gray-200">Home</a>
+      <a href="/daily-log" class="hover:text-gray-200">Daily Log</a>
+      <a href="/fitness" class="hover:text-gray-200">Fitness</a>
+      <a href="/projects" class="hover:text-gray-200">Projects</a>
+      <a href="/reviews" class="hover:text-gray-200">Reviews</a>
+    </nav>
+  </div>
+</aside>
+<script>
+  const timeEl = document.getElementById('sidebar-time');
+  const dateEl = document.getElementById('sidebar-date');
+  function updateClock() {
+    const now = new Date();
+    timeEl.textContent = now.toLocaleTimeString();
+    dateEl.textContent = now.toLocaleDateString();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import PasswordGate from '../components/PasswordGate.astro';
 ---
 <html lang="en" class="dark">
   <head>
@@ -10,7 +11,8 @@ import '../styles/global.css';
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   </head>
-  <body class="bg-black text-gray-100 font-jetbrains min-h-screen">
+  <body class="bg-black text-gray-100 font-jetbrains min-h-screen overflow-x-hidden">
     <slot />
+    <PasswordGate />
   </body>
 </html>

--- a/src/pages/daily-log.astro
+++ b/src/pages/daily-log.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/pages/fitness.astro
+++ b/src/pages/fitness.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,33 +2,41 @@
 
 import IntroOverlay from '../components/IntroOverlay.astro';
 import Navbar from '../components/Navbar.astro';
+import Sidebar from '../components/Sidebar.astro';
+import MissionPanel from '../components/MissionPanel.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <IntroOverlay />
-  <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
-    <section class="border-b border-gray-800 pb-4">
-      <h1 class="text-2xl mb-2">This Week’s Focus</h1>
-      <p class="text-lg text-gray-300">Minimize distractions. Maximize presence. No wasted motion.</p>
-    </section>
-    <section>
-      <textarea
-        id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
-        rows="4"
-        placeholder="Type your focus, reflection, or insight..."
-      ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
-    </section>
-    <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
-    </section>
-    <section class="text-center italic text-gray-400 pt-8">
-      “In the dark, I’ll find the power to rise.”
-    </section>
-  </main>
+  <div class="lg:grid lg:grid-cols-[auto_1fr_auto] min-h-screen">
+    <Sidebar />
+    <div class="lg:hidden border-b border-gray-800">
+      <Navbar />
+    </div>
+    <main class="p-4 sm:p-6 space-y-6">
+      <section class="border-b border-gray-800 pb-4">
+        <h1 class="text-lg sm:text-xl mb-2">This Week’s Focus</h1>
+        <p class="text-sm sm:text-base text-gray-300">Minimize distractions. Maximize presence. No wasted motion.</p>
+      </section>
+      <section>
+        <textarea
+          id="log-text"
+          class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
+          rows="4"
+          placeholder="Type your focus, reflection, or insight..."
+        ></textarea>
+        <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
+      </section>
+      <section>
+        <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+        <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
+      </section>
+      <section class="text-center italic text-gray-400 pt-8 text-sm sm:text-base">
+        “In the dark, I’ll find the power to rise.”
+      </section>
+    </main>
+    <MissionPanel />
+  </div>
   <script>
     const textarea = document.getElementById('log-text');
     const logList = document.getElementById('recent-logs');

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/pages/reviews.astro
+++ b/src/pages/reviews.astro
@@ -4,19 +4,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
   <Navbar />
-  <main class="max-w-2xl mx-auto p-8 space-y-8">
+  <main class="max-w-2xl mx-auto p-4 sm:p-6 space-y-6">
     <section>
       <textarea
         id="log-text"
-        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 mb-4 font-mono focus:outline-none"
+        class="w-full bg-transparent border-b border-gray-700 text-gray-100 placeholder-gray-500 p-2 sm:p-3 text-sm sm:text-base mb-4 font-mono focus:outline-none resize-none"
         rows="4"
         placeholder="Type your log entry..."
       ></textarea>
-      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded transition">Log Entry</button>
+      <button id="log-button" class="bg-gray-700 hover:bg-gray-600 text-sm sm:text-base px-2 py-1 sm:px-3 sm:py-2 rounded">Log Entry</button>
     </section>
     <section>
-      <h2 class="mb-2 text-lg">Recent Logs</h2>
-      <div id="recent-logs" class="font-mono text-gray-400 space-y-1"></div>
+      <h2 class="mb-2 text-sm sm:text-lg">Recent Logs</h2>
+      <div id="recent-logs" class="font-mono text-gray-400 space-y-2 text-sm sm:text-base"></div>
     </section>
   </main>
   <script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,27 @@
 
 @layer base {
   html {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: "JetBrains Mono", monospace;
+  }
+  body {
+    @apply overflow-x-hidden;
+  }
+}
+
+@layer utilities {
+  @keyframes shake {
+    0%,
+    100% {
+      transform: translateX(0);
+    }
+    25% {
+      transform: translateX(-4px);
+    }
+    75% {
+      transform: translateX(4px);
+    }
+  }
+  .animate-shake {
+    animation: shake 0.3s;
   }
 }


### PR DESCRIPTION
## Summary
- add PasswordGate overlay to restrict access until passcode entered
- listen for auth event in IntroOverlay before fading out
- include the password gate in the base layout
- add shake animation for incorrect codes
- redesign homepage into a three-column tactical layout with sidebar and mission panel

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68428acd007c832285c37c387743b4a9