### PR TITLE
Add vault-style password protection

### DIFF
--- a/src/components/IntroOverlay.astro
+++ b/src/components/IntroOverlay.astro
@@ -17,5 +17,5 @@
     setTimeout(() => overlay.remove(), 1000);
   };
   overlay.addEventListener('click', hide);
-  setTimeout(hide, 3000);
+  window.addEventListener('arkham-access-granted', hide);
 </script>

--- a/src/components/PasswordGate.astro
+++ b/src/components/PasswordGate.astro
@@ -1,0 +1,41 @@
+---
+---
+<div id="password-gate" class="fixed inset-0 z-50 bg-black flex items-center justify-center">
+  <div class="text-green-500 font-jetbrains text-center space-y-3">
+    <label for="arkham-pass" class="block">ENTER ACCESS CODE:</label>
+    <input id="arkham-pass" type="password" autocomplete="off" class="bg-black text-green-500 border-b border-green-500 focus:outline-none text-center w-40" />
+    <div id="denied-msg" class="text-red-500 mt-2 hidden">ACCESS DENIED</div>
+  </div>
+</div>
+<style>
+@keyframes shake {0%,100%{transform:translateX(0);}20%,60%{transform:translateX(-4px);}40%,80%{transform:translateX(4px);}}
+#password-gate.shake {animation: shake 0.3s;}
+</style>
+<script>
+(function(){
+  const gate=document.getElementById('password-gate');
+  const input=document.getElementById('arkham-pass');
+  const denied=document.getElementById('denied-msg');
+  const expected='6c25c8f454fea8dd5cd0b201b4f739993aebfc454de7b410ee9457c553699a85';
+  const hash=async val=>{
+    const buf=await crypto.subtle.digest('SHA-256',new TextEncoder().encode(val));
+    return Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('');
+  };
+  const grant=()=>{
+    sessionStorage.setItem('arkhamAccess','1');
+    gate.classList.add('opacity-0');
+    setTimeout(()=>{gate.remove();window.dispatchEvent(new CustomEvent('arkham-access-granted'));},300);
+  };
+  const deny=()=>{
+    denied.classList.remove('hidden');
+    gate.classList.add('shake');
+    setTimeout(()=>gate.classList.remove('shake'),300);
+  };
+  if(sessionStorage.getItem('arkhamAccess')==='1'){
+    grant();
+  }else{
+    input.focus();
+    gate.addEventListener('keydown',e=>{if(e.key==='Enter'){hash(input.value).then(h=>h===expected?grant():deny());}});
+  }
+})();
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,7 @@
 ---
 import '../styles/global.css';
+import IntroOverlay from '../components/IntroOverlay.astro';
+import PasswordGate from '../components/PasswordGate.astro';
 ---
 <html lang="en" class="dark">
   <head>
@@ -11,6 +13,8 @@ import '../styles/global.css';
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   </head>
   <body class="bg-black text-gray-100 font-jetbrains min-h-screen overflow-x-hidden">
+    <PasswordGate />
+    <IntroOverlay />
     <slot />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,9 @@
 ---
 
-import IntroOverlay from '../components/IntroOverlay.astro';
 import Navbar from '../components/Navbar.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout>
-  <IntroOverlay />
   <Navbar />
   <main class="max-w-2xl mx-auto p-4 sm:p-8 space-y-8">
     <section class="border-b border-gray-800 pb-4">


### PR DESCRIPTION
## Summary
- create PasswordGate component to require access code
- update IntroOverlay to fade out when access granted
- load new gate and overlay from BaseLayout
- remove overlay include from index page

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684350072b14832282a776449276e1e7